### PR TITLE
Add chat sockets and notifications

### DIFF
--- a/nikosale-frontend/src/api/axios.js
+++ b/nikosale-frontend/src/api/axios.js
@@ -5,4 +5,12 @@ const api = axios.create({
   withCredentials: true, // если используешь куки для аутентификации
 });
 
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export default api;

--- a/nikosale-frontend/src/components/NotificationsList.jsx
+++ b/nikosale-frontend/src/components/NotificationsList.jsx
@@ -1,24 +1,6 @@
-import {MessageCircle, Share2, Star, UserCheck} from 'lucide-react';
 
-export default function NotificationsList() {
-    const notifications = [
-        {
-            icon: <MessageCircle className="w-5 h-5 text-blue-500"/>,
-            text: 'Новое сообщение от клиента',
-        },
-        {
-            icon: <Share2 className="w-5 h-5 text-green-500"/>,
-            text: 'Сообщение передано менеджеру',
-        },
-        {
-            icon: <Star className="w-5 h-5 text-yellow-500"/>,
-            text: 'Ура! Новый отзыв от покупателя',
-        },
-        {
-            icon: <UserCheck className="w-5 h-5 text-purple-500"/>,
-            text: 'Менеджер принял приглашение',
-        },
-    ];
+export default function NotificationsList({items}) {
+    const notifications = items || [];
 
     return (
         <div className="w-72 max-h-96 overflow-y-auto">

--- a/nikosale-frontend/src/pages/ChatPage.jsx
+++ b/nikosale-frontend/src/pages/ChatPage.jsx
@@ -1,4 +1,5 @@
 import React, {useState, useEffect, useRef} from 'react';
+import api from '../api/axios';
 import {ChevronLeft} from 'lucide-react';
 import {Send} from 'lucide-react';
 import TextareaAutosize from 'react-textarea-autosize';
@@ -10,10 +11,10 @@ export function useChatSocket(selectedUser, onMessageReceived) {
     useEffect(() => {
         if (!selectedUser) return;
 
-        const ws = new WebSocket(`ws://localhost:8000/ws/${selectedUser.id}`);
+        const ws = new WebSocket(`ws://localhost:8000/ws/chat/${selectedUser.external_id}/`);
         wsRef.current = ws;
 
-        ws.onopen = () => console.log('🔌 WebSocket открыт для', selectedUser.name);
+        ws.onopen = () => console.log('🔌 WebSocket открыт для', selectedUser.external_id);
         ws.onmessage = (event) => {
             const data = JSON.parse(event.data);
             onMessageReceived(data);
@@ -221,29 +222,7 @@ const getMessageStyle = (sender) => {
 };
 
 
-const users = [
-    {id: 1, name: 'Иван Иванов'},
-    {id: 2, name: 'Мария Смирнова'},
-    {id: 3, name: 'Мария Смирнова'},
-    {id: 4, name: 'Мария Смирнова'},
-    {id: 5, name: 'Мария Смирнова'},
-    {id: 6, name: 'Мария Смирнова'},
-    {id: 7, name: 'Мария Смирнова'},
-    {id: 8, name: 'Мария Смирнова'},
-    {id: 9, name: 'Мария Смирнова'},
-    {id: 10, name: 'Мария Смирнова'},
-    {id: 11, name: 'Мария Смирнова'},
-    {id: 12, name: 'Мария Смирнова'},
-    {id: 13, name: 'Мария Смирнова'},
-    {id: 14, name: 'Мария Смирнова'},
-    {id: 15, name: 'Мария Смирнова'},
-    {id: 16, name: 'Мария Смирнова'},
-    {id: 17, name: 'Мария Смирнова'},
-    {id: 18, name: 'Мария Смирнова'},
-    {id: 19, name: 'Мария Смирнова'},
-    {id: 20, name: 'Мария Смирнова'},
-    {id: 21, name: 'Алексей Кузнецов'},
-];
+const usersPlaceholder = [];
 
 const getColorFromChar = (char) => {
     const colors = [
@@ -263,11 +242,12 @@ export default function ChatPage() {
     const [message, setMessage] = useState('');
     const [loadingMessages, setLoadingMessages] = useState(false);
     const [messages, setMessages] = useState([]);
+    const [users, setUsers] = useState(usersPlaceholder);
     const wsRef = useRef(null);
     const {sendMessage} = useChatSocket(selectedUser, (data) => {
         console.log('📨 Получено сообщение:', data);
 
-        if (selectedUser && data.from === selectedUser.id) {
+        if (selectedUser && data.from === selectedUser.external_id) {
             setMessages((prev) => [
                 ...prev,
                 {
@@ -287,6 +267,12 @@ export default function ChatPage() {
     });
 
     useEffect(() => {
+        api.get('shop_users/')
+            .then((res) => setUsers(res.data))
+            .catch((e) => console.error('Ошибка загрузки пользователей', e));
+    }, []);
+
+    useEffect(() => {
         if (isNearBottom()) {
             scrollToBottom('smooth');
         } else {
@@ -300,7 +286,7 @@ export default function ChatPage() {
         // Если WebSocket подключён — отправляем
         if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN && selectedUser) {
             wsRef.current.send(JSON.stringify({
-                to: selectedUser.id,   // ID получателя
+                to: selectedUser.external_id,   // ID получателя
                 message: message.trim() // Текст сообщения
             }));
         } else {
@@ -328,7 +314,7 @@ export default function ChatPage() {
         if (selectedUser) {
             setUnreadByUser(prev => {
                 const copy = {...prev};
-                delete copy[selectedUser.id];
+                delete copy[selectedUser.external_id];
                 return copy;
             });
         }
@@ -438,11 +424,11 @@ export default function ChatPage() {
                         <h2 className="text-xl font-semibold mb-4">Выберите пользователя</h2>
                         <ul className="space-y-2">
                             {users.map((user) => {
-                                const initial = user.name[0];
+                                const initial = user.external_id[0];
                                 const color = getColorFromChar(initial);
                                 return (
                                     <li
-                                        key={user.id}
+                                        key={user.external_id}
                                         onClick={() => setSelectedUser(user)}
                                         className="flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-gray-100 transition"
                                     >
@@ -452,11 +438,11 @@ export default function ChatPage() {
                                             {initial}
                                         </div>
                                         <span className="text-sm font-medium flex items-center gap-2">
-    {user.name}
-                                            {unreadByUser[user.id] && (
+    {user.external_id}
+                                            {unreadByUser[user.external_id] && (
                                                 <span
                                                     className="ml-1 bg-red-500 text-white text-xs px-1.5 py-0.5 rounded-full">
-            {unreadByUser[user.id]}
+            {unreadByUser[user.external_id]}
         </span>
                                             )}
 </span>
@@ -479,7 +465,7 @@ export default function ChatPage() {
                             >
                                 <ChevronLeft className="w-6 h-6"/>
                             </button>
-                            <h2 className="text-lg font-semibold">{selectedUser.name}</h2>
+                            <h2 className="text-lg font-semibold">{selectedUser.external_id}</h2>
                         </div>
 
                         {/* Контейнер сообщений */}
@@ -576,14 +562,14 @@ export default function ChatPage() {
                 <h2 className="text-xl font-semibold mb-4">Пользователи</h2>
                 <ul className="space-y-2">
                     {users.map((user) => {
-                        const initial = user.name[0];
+                        const initial = user.external_id[0];
                         const color = getColorFromChar(initial);
                         return (
                             <li
-                                key={user.id}
+                                key={user.external_id}
                                 onClick={() => setSelectedUser(user)}
                                 className={`flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-gray-100 transition ${
-                                    selectedUser && user.id === selectedUser.id ? 'bg-gray-100' : ''
+                                    selectedUser && user.external_id === selectedUser.external_id ? 'bg-gray-100' : ''
                                 }`}
                             >
                                 <div
@@ -591,7 +577,7 @@ export default function ChatPage() {
                                 >
                                     {initial}
                                 </div>
-                                <span className="text-sm font-medium">{user.name}</span>
+                                <span className="text-sm font-medium">{user.external_id}</span>
                             </li>
                         );
                     })}
@@ -602,7 +588,7 @@ export default function ChatPage() {
             {selectedUser ? (
                 <main className="relative flex flex-col flex-1 h-full overflow-hidden">
                     <div className="border-b px-6 py-4 text-lg font-semibold bg-white">
-                        {selectedUser.name}
+                        {selectedUser.external_id}
                     </div>
 
                     <div className="flex flex-col flex-1 overflow-hidden">

--- a/nikosale-frontend/src/pages/Layout.jsx
+++ b/nikosale-frontend/src/pages/Layout.jsx
@@ -43,7 +43,8 @@ export default function SidebarLayout({children}) {
     };
     const location = useLocation();
     const [unreadChats, setUnreadChats] = useState(true);
-    const [unreadNotifications, setUnreadNotifications] = useState(true);
+    const [unreadNotifications, setUnreadNotifications] = useState(false);
+    const [notifications, setNotifications] = useState([]);
     const title = pageTitles[location.pathname] || 'Заголовок';
     const menuItems = [
         {icon: <MessageSquare size={20}/>, label: 'Чаты', path: '/chats'},
@@ -81,6 +82,16 @@ export default function SidebarLayout({children}) {
         document.addEventListener('mousedown', handleClickOutside);
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [isSidebarOpen]);
+
+    useEffect(() => {
+        const ws = new WebSocket('ws://localhost:8000/ws/notifications/');
+        ws.onmessage = (e) => {
+            const data = JSON.parse(e.data);
+            setNotifications((prev) => [...prev, {text: data.message}]);
+            setUnreadNotifications(true);
+        };
+        return () => ws.close();
+    }, []);
 
 
     return (
@@ -147,9 +158,9 @@ export default function SidebarLayout({children}) {
                     </div>
                     <div className="relative">
                         <DropdownLayout
-                            trigger={<Bell size={20} className="text-gray-600"/>}
+                            trigger={<div onClick={() => setUnreadNotifications(false)}><Bell size={20} className="text-gray-600"/></div>}
                         >
-<NotificationsList />
+<NotificationsList items={notifications} />
                         </DropdownLayout>
 
                         {unreadNotifications && (
@@ -222,9 +233,9 @@ export default function SidebarLayout({children}) {
                             </div>
                             <div className="relative">
                                 <DropdownLayout
-                                    trigger={<Bell size={20} className="text-gray-600"/>}
+                                    trigger={<div onClick={() => setUnreadNotifications(false)}><Bell size={20} className="text-gray-600"/></div>}
                                 >
-<NotificationsList />
+<NotificationsList items={notifications} />
                                 </DropdownLayout>
                                 {unreadNotifications && (
                                     <span

--- a/tg_shop/core/consumers.py
+++ b/tg_shop/core/consumers.py
@@ -41,3 +41,20 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 "message": event["message"],
             })
         )
+
+
+class NotificationConsumer(AsyncWebsocketConsumer):
+    """WebSocket-консюмер для уведомлений."""
+
+    async def connect(self) -> None:
+        """Подключает клиента к общей группе уведомлений."""
+        await self.channel_layer.group_add("notifications", self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code: int) -> None:
+        """Отключает клиента от группы уведомлений."""
+        await self.channel_layer.group_discard("notifications", self.channel_name)
+
+    async def notify(self, event: dict) -> None:
+        """Отправляет событие уведомления пользователю."""
+        await self.send(text_data=json.dumps({"message": event["message"]}))

--- a/tg_shop/core/routing.py
+++ b/tg_shop/core/routing.py
@@ -2,9 +2,10 @@
 
 from django.urls import re_path
 
-from .consumers import ChatConsumer
+from .consumers import ChatConsumer, NotificationConsumer
 
 # Паттерны URL для обработки websocket-подключений
 websocket_urlpatterns = [
     re_path(r"^ws/chat/(?P<user_id>\w+)/$", ChatConsumer.as_asgi()),
+    re_path(r"^ws/notifications/$", NotificationConsumer.as_asgi()),
 ]

--- a/tg_shop/core/urls.py
+++ b/tg_shop/core/urls.py
@@ -7,7 +7,8 @@ from .views import (
     GenerateInviteLinkView,
     RegisterViaTokenView, ConfirmInviteView, MarketplaceTokenViewSet, ProductViewSet, QuestionAnswerViewSet,
     ProductQuestionViewSet, ProductQuestionMessageViewSet, ExternalQuestionCreateView, UserConversationView,
-    ShopUserListView
+    ShopUserListView,
+    NotificationSendView,
 )
 
 from rest_framework import permissions
@@ -33,4 +34,5 @@ urlpatterns = [
     path('', include(router.urls)),
     path('external/questions/', ExternalQuestionCreateView.as_view(), name='external-question'),
     path('invite/<uuid:token>/confirm/', ConfirmInviteView.as_view(), name='invite-confirm'),
+    path('notify/', NotificationSendView.as_view(), name='notify'),
 ]

--- a/tg_shop/core/views.py
+++ b/tg_shop/core/views.py
@@ -5,6 +5,8 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
 from drf_yasg import openapi
 from .permissions import IsOwnerOrManager, IsAuthenticatedOrAPISecret
 from .serializers import RegisterUserSerializer, MarketplaceTokenSerializer, ProductSerializer, \
@@ -468,4 +470,30 @@ class ShopUserListView(APIView):
 
         sorted_users = sorted(result.values(), key=lambda x: x["first_message"])
         return Response(sorted_users)
+
+
+class NotificationSendView(APIView):
+    """Отправка уведомления всем подключённым клиентам."""
+
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        operation_description="Отправить уведомление всем пользователям",
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            required=["message"],
+            properties={"message": openapi.Schema(type=openapi.TYPE_STRING)},
+        ),
+        responses={200: openapi.Response(description="Уведомление отправлено")},
+    )
+    def post(self, request):
+        message = request.data.get("message")
+        if not message:
+            return Response({"error": "message is required"}, status=400)
+
+        channel_layer = get_channel_layer()
+        async_to_sync(channel_layer.group_send)(
+            "notifications", {"type": "notify", "message": message}
+        )
+        return Response({"status": "ok"})
 


### PR DESCRIPTION
## Summary
- fetch JWT-protected user list on the chat page
- use WebSocket URL that matches Django routing
- send push notifications via WebSocket
- add NotificationConsumer and API endpoint to publish notifications

## Testing
- `python manage.py test`
- `npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6861369802248326a553dcc63b329d0b