### PR TITLE
Fix dotenv loading for uvicorn

### DIFF
--- a/tg_shop/tg_shop/asgi.py
+++ b/tg_shop/tg_shop/asgi.py
@@ -1,15 +1,9 @@
-"""
-ASGI config for tg_shop project.
-
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
-"""
-
-"""ASGI-приложение с поддержкой WebSocket."""
+"""ASGI-приложение для проекта tg_shop с поддержкой WebSocket."""
 
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
 
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
@@ -17,6 +11,7 @@ from django.core.asgi import get_asgi_application
 
 from core.routing import websocket_urlpatterns
 
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tg_shop.settings")
 
 django_app = get_asgi_application()

--- a/tg_shop/tg_shop/wsgi.py
+++ b/tg_shop/tg_shop/wsgi.py
@@ -1,16 +1,12 @@
-"""
-WSGI config for tg_shop project.
-
-It exposes the WSGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
-"""
+"""WSGI-приложение для проекта tg_shop."""
 
 import os
+from pathlib import Path
 
+from dotenv import load_dotenv
 from django.core.wsgi import get_wsgi_application
 
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tg_shop.settings')
 
 application = get_wsgi_application()


### PR DESCRIPTION
## Summary
- ensure `.env` is loaded when running `uvicorn`

## Testing
- `python tg_shop/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6861408d56f48326800af6aa7eae1201