### PR TITLE
Add FastAPI prototype with WebSocket support

### DIFF
--- a/fastapi_app/dependencies.py
+++ b/fastapi_app/dependencies.py
@@ -1,0 +1,17 @@
+"""Вспомогательные зависимости для FastAPI."""
+
+from fastapi import Header, HTTPException, status
+from pydantic import BaseModel
+
+
+class ApiSecret(BaseModel):
+    secret: str
+
+
+async def verify_api_secret(x_api_secret: str | None = Header(default=None)) -> None:
+    """Проверяет заголовок `X-API-SECRET`."""
+    from os import getenv
+
+    expected = getenv("EXTERNAL_API_SECRET")
+    if not x_api_secret or x_api_secret != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API secret")

--- a/fastapi_app/main.py
+++ b/fastapi_app/main.py
@@ -1,0 +1,59 @@
+"""Запуск FastAPI-приложения с поддержкой WebSocket."""
+
+from uuid import uuid4
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Depends
+from pydantic import BaseModel
+
+from .websocket_manager import WebSocketManager
+from .dependencies import verify_api_secret
+
+
+app = FastAPI(title="NikoSale API")
+manager = WebSocketManager()
+
+
+class NotifyMessage(BaseModel):
+    """Модель сообщения для отправки уведомлений."""
+
+    message: str
+
+
+@app.post("/notify", dependencies=[Depends(verify_api_secret)])
+async def notify(message: NotifyMessage) -> dict:
+    """Рассылает уведомление всем подключённым клиентам."""
+    await manager.broadcast(message.message)
+    return {"status": "ok"}
+
+
+@app.websocket("/ws/notifications")
+async def websocket_notifications(websocket: WebSocket) -> None:
+    """Подключение для получения уведомлений в реальном времени."""
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()  # поддерживаем соединение
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)
+
+from .questions import ProductQuestion, create_question, list_questions
+
+class QuestionIn(BaseModel):
+    external_id: str
+    product_id: int
+    text: str
+    marketplace: str | None = None
+
+
+@app.post("/external/questions", dependencies=[Depends(verify_api_secret)])
+async def external_question(question: QuestionIn) -> ProductQuestion:
+    """Создаёт вопрос от внешней системы."""
+    q = ProductQuestion(id=str(uuid4()), **question.dict())
+    return create_question(q)
+
+
+@app.get("/external/questions", response_model=list[ProductQuestion], dependencies=[Depends(verify_api_secret)])
+async def external_question_list() -> list[ProductQuestion]:
+    """Список отправленных вопросов."""
+    return list_questions()
+

--- a/fastapi_app/questions.py
+++ b/fastapi_app/questions.py
@@ -1,0 +1,30 @@
+"""Примитивное хранение вопросов о товарах."""
+
+from typing import List
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+
+class ProductQuestion(BaseModel):
+    """Модель вопроса."""
+
+    id: str
+    external_id: str
+    product_id: int
+    text: str
+    marketplace: str | None = None
+
+
+_questions: List[ProductQuestion] = []
+
+
+def create_question(data: ProductQuestion) -> ProductQuestion:
+    """Сохраняет вопрос в памяти."""
+    _questions.append(data)
+    return data
+
+
+def list_questions() -> List[ProductQuestion]:
+    """Возвращает все вопросы."""
+    return _questions

--- a/fastapi_app/websocket_manager.py
+++ b/fastapi_app/websocket_manager.py
@@ -1,0 +1,28 @@
+"""Утилита для управления WebSocket-подключениями."""
+
+from typing import Set
+from fastapi import WebSocket
+
+
+class WebSocketManager:
+    """Простой менеджер подключений."""
+
+    def __init__(self) -> None:
+        self.active_connections: Set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        """Подключение клиента."""
+        await websocket.accept()
+        self.active_connections.add(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        """Отключение клиента."""
+        self.active_connections.discard(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        """Отправляет сообщение всем подключённым клиентам."""
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_text(message)
+            except Exception:
+                self.disconnect(connection)


### PR DESCRIPTION
## Summary
- introduce a simple FastAPI application alongside the Django project
- implement a `WebSocketManager` and notification WebSocket endpoint
- expose `/notify` endpoint protected by `X-API-SECRET`
- add primitive in-memory product question endpoints as an example

## Testing
- `python -m py_compile fastapi_app/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614734a4f88326a1d0c6d6a0fa1240