### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/fastapi_app/README.md
+++ b/fastapi_app/README.md
@@ -1,0 +1,3 @@
+# Niko Sale FastAPI
+
+Минимальное FastAPI приложение для демонстрации работы с PostgreSQL и MinIO.

--- a/fastapi_app/app/__init__.py
+++ b/fastapi_app/app/__init__.py
@@ -1,0 +1,1 @@
+from .main import app

--- a/fastapi_app/app/config.py
+++ b/fastapi_app/app/config.py
@@ -1,0 +1,15 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    """Конфигурация приложения, загруженная из окружения."""
+
+    database_url: str = "postgresql+asyncpg://root_user:secret@localhost:5433/tgshop"
+    minio_endpoint: str = "http://localhost:9000"
+    minio_access_key: str = "minioadmin"
+    minio_secret_key: str = "minioadmin"
+    minio_bucket: str = "tgshop"
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()

--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -1,0 +1,114 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from . import models, schemas
+
+class ManagerCRUD:
+    """CRUD операции для менеджеров."""
+
+    @staticmethod
+    async def create(session: AsyncSession, data: schemas.ManagerCreate) -> models.Manager:
+        manager = models.Manager(**data.dict())
+        session.add(manager)
+        await session.commit()
+        await session.refresh(manager)
+        return manager
+
+    @staticmethod
+    async def get_list(session: AsyncSession) -> list[models.Manager]:
+        result = await session.execute(select(models.Manager))
+        return result.scalars().all()
+
+    @staticmethod
+    async def get(session: AsyncSession, manager_id: int) -> models.Manager | None:
+        result = await session.execute(select(models.Manager).where(models.Manager.id == manager_id))
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def delete(session: AsyncSession, manager_id: int) -> None:
+        manager = await ManagerCRUD.get(session, manager_id)
+        if manager:
+            await session.delete(manager)
+            await session.commit()
+
+class TokenCRUD:
+    """CRUD для токенов маркетплейсов."""
+
+    @staticmethod
+    async def add(session: AsyncSession, data: schemas.MarketplaceTokenCreate) -> models.MarketplaceToken:
+        token = models.MarketplaceToken(**data.dict())
+        session.add(token)
+        await session.commit()
+        await session.refresh(token)
+        return token
+
+    @staticmethod
+    async def delete(session: AsyncSession, store_id: int, service_name: str) -> None:
+        result = await session.execute(
+            select(models.MarketplaceToken).where(
+                models.MarketplaceToken.store_id == store_id,
+                models.MarketplaceToken.service_name == service_name,
+            )
+        )
+        token = result.scalar_one_or_none()
+        if token:
+            await session.delete(token)
+            await session.commit()
+
+    @staticmethod
+    async def list(session: AsyncSession, store_id: int) -> list[models.MarketplaceToken]:
+        result = await session.execute(
+            select(models.MarketplaceToken).where(models.MarketplaceToken.store_id == store_id)
+        )
+        return result.scalars().all()
+
+class ProductCRUD:
+    """CRUD для продуктов."""
+
+    @staticmethod
+    async def create(session: AsyncSession, data: schemas.ProductCreate, image_keys: list[str]) -> models.Product:
+        product = models.Product(
+            title=data.title,
+            description=data.description,
+            specifications=data.specifications,
+            marketplaces=data.marketplaces,
+            image_keys=image_keys,
+        )
+        session.add(product)
+        await session.commit()
+        await session.refresh(product)
+        return product
+
+    @staticmethod
+    async def get(session: AsyncSession, product_id: int) -> models.Product | None:
+        result = await session.execute(select(models.Product).where(models.Product.id == product_id))
+        return result.scalar_one_or_none()
+
+    @staticmethod
+    async def list(session: AsyncSession) -> list[models.Product]:
+        result = await session.execute(select(models.Product))
+        return result.scalars().all()
+
+class ConversationCRUD:
+    """CRUD для сообщений переписки."""
+
+    @staticmethod
+    async def add_message(session: AsyncSession, data: schemas.ConversationMessageCreate) -> models.ConversationMessage:
+        msg = models.ConversationMessage(
+            external_id=data.external_id,
+            product_id=data.product,
+            text=data.text,
+            marketplace=data.marketplace,
+            from_manager=data.from_manager,
+        )
+        session.add(msg)
+        await session.commit()
+        await session.refresh(msg)
+        return msg
+
+    @staticmethod
+    async def get_by_external_id(session: AsyncSession, external_id: str) -> list[models.ConversationMessage]:
+        result = await session.execute(
+            select(models.ConversationMessage).where(models.ConversationMessage.external_id == external_id)
+        )
+        return result.scalars().all()

--- a/fastapi_app/app/database.py
+++ b/fastapi_app/app/database.py
@@ -1,0 +1,19 @@
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+from .config import settings
+
+engine = create_async_engine(settings.database_url, echo=False, future=True)
+
+AsyncSessionLocal = sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+Base = declarative_base()
+
+async def get_session() -> AsyncSession:
+    """Провайдер сессий для FastAPI."""
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+
+from .routers import managers, tokens, products, conversations
+
+app = FastAPI(title="Niko Sale API")
+
+app.include_router(managers.router)
+app.include_router(tokens.router)
+app.include_router(products.router)
+app.include_router(conversations.router)

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, Integer, String, JSON, ForeignKey, Text, Boolean
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+class Manager(Base):
+    """Модель менеджера магазина."""
+
+    __tablename__ = "managers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(128), unique=True, nullable=False)
+    email = Column(String(255), unique=True, nullable=False)
+    telegram_id = Column(Integer, nullable=True)
+    contact_phone = Column(String(32), nullable=True)
+
+class MarketplaceToken(Base):
+    """Токен для интеграции с маркетплейсом."""
+
+    __tablename__ = "marketplace_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    store_id = Column(Integer, nullable=False)
+    service_name = Column(String(64), nullable=False)
+    token = Column(String(512), nullable=False)
+
+class Product(Base):
+    """Продукт магазина."""
+
+    __tablename__ = "products"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    specifications = Column(JSON, nullable=True)
+    marketplaces = Column(JSON, nullable=True)
+    image_keys = Column(JSON, nullable=True)
+
+class ConversationMessage(Base):
+    """Сообщение в переписке пользователя с менеджером."""
+
+    __tablename__ = "conversation_messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    external_id = Column(String(64), nullable=False)
+    product_id = Column(Integer, ForeignKey("products.id"), nullable=False)
+    text = Column(Text, nullable=False)
+    marketplace = Column(String(64), nullable=False)
+    from_manager = Column(Boolean, default=False, nullable=False)
+
+    product = relationship("Product")

--- a/fastapi_app/app/routers/conversations.py
+++ b/fastapi_app/app/routers/conversations.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import schemas, crud
+from ..database import get_session
+
+router = APIRouter(tags=["conversations"])
+
+@router.post("/api/external/questions/", response_model=schemas.ConversationMessageRead)
+async def ask_question(data: schemas.ConversationMessageCreate, session: AsyncSession = Depends(get_session)):
+    """Пользователь задаёт вопрос."""
+    return await crud.ConversationCRUD.add_message(session, data)
+
+@router.get("/api/conversations/")
+async def get_conversation(external_id: str, session: AsyncSession = Depends(get_session)):
+    """Получить переписку по external_id."""
+    return await crud.ConversationCRUD.get_by_external_id(session, external_id)

--- a/fastapi_app/app/routers/managers.py
+++ b/fastapi_app/app/routers/managers.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import schemas, crud
+from ..database import get_session
+
+router = APIRouter(prefix="/api/managers", tags=["managers"])
+
+@router.post("/", response_model=schemas.ManagerRead)
+async def create_manager(data: schemas.ManagerCreate, session: AsyncSession = Depends(get_session)):
+    """Создание нового менеджера."""
+    return await crud.ManagerCRUD.create(session, data)
+
+@router.get("/", response_model=list[schemas.ManagerRead])
+async def list_managers(session: AsyncSession = Depends(get_session)):
+    """Возвращает список менеджеров."""
+    return await crud.ManagerCRUD.get_list(session)
+
+@router.get("/{manager_id}", response_model=schemas.ManagerRead)
+async def get_manager(manager_id: int, session: AsyncSession = Depends(get_session)):
+    """Получить менеджера по идентификатору."""
+    manager = await crud.ManagerCRUD.get(session, manager_id)
+    if not manager:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return manager
+
+@router.delete("/{manager_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_manager(manager_id: int, session: AsyncSession = Depends(get_session)):
+    """Удалить менеджера."""
+    await crud.ManagerCRUD.delete(session, manager_id)

--- a/fastapi_app/app/routers/products.py
+++ b/fastapi_app/app/routers/products.py
@@ -1,0 +1,44 @@
+from fastapi import HTTPException, APIRouter, Depends, UploadFile, File
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import schemas, crud
+from ..database import get_session
+from ..storage import MinioStorage
+
+router = APIRouter(prefix="/api/products", tags=["products"])
+
+storage = MinioStorage()
+
+@router.post("/", response_model=schemas.ProductRead)
+async def create_product(
+    title: str,
+    description: str | None = None,
+    specifications: str | None = None,
+    marketplaces: list[str] | None = None,
+    images: list[UploadFile] | None = File(None),
+    session: AsyncSession = Depends(get_session),
+):
+    """Создаёт продукт с загрузкой изображений в MinIO."""
+    files_data = [await f.read() for f in images] if images else []
+    keys = storage.upload_files(files_data) if files_data else []
+    data = schemas.ProductCreate(
+        title=title,
+        description=description,
+        specifications=specifications,
+        marketplaces=marketplaces,
+    )
+    product = await crud.ProductCRUD.create(session, data, keys)
+    return product
+
+@router.get("/{product_id}", response_model=schemas.ProductRead)
+async def get_product(product_id: int, session: AsyncSession = Depends(get_session)):
+    """Получить продукт по ID."""
+    product = await crud.ProductCRUD.get(session, product_id)
+    if not product:
+        raise HTTPException(status_code=404)
+    return product
+
+@router.get("/", response_model=list[schemas.ProductRead])
+async def list_products(session: AsyncSession = Depends(get_session)):
+    """Список продуктов."""
+    return await crud.ProductCRUD.list(session)

--- a/fastapi_app/app/routers/tokens.py
+++ b/fastapi_app/app/routers/tokens.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import schemas, crud
+from ..database import get_session
+
+router = APIRouter(prefix="/api/stores/{store_id}/marketplace-tokens", tags=["tokens"])
+
+@router.post("/")
+async def add_token(store_id: int, data: schemas.MarketplaceTokenCreate, session: AsyncSession = Depends(get_session)):
+    """Добавить токен маркетплейса."""
+    token = schemas.MarketplaceTokenCreate(**data.dict(), store_id=store_id)
+    return await crud.TokenCRUD.add(session, token)
+
+@router.delete("/{service_name}")
+async def delete_token(store_id: int, service_name: str, session: AsyncSession = Depends(get_session)):
+    """Удалить токен."""
+    await crud.TokenCRUD.delete(session, store_id, service_name)
+    return {"status": "deleted"}
+
+@router.get("/")
+async def list_tokens(store_id: int, session: AsyncSession = Depends(get_session)):
+    """Список токенов магазина."""
+    return await crud.TokenCRUD.list(session, store_id)

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -1,0 +1,59 @@
+from typing import Optional, List, Any
+from pydantic import BaseModel, Field
+
+class ManagerCreate(BaseModel):
+    """Схема создания менеджера."""
+
+    username: str
+    email: str
+    telegram_id: Optional[int] = None
+    contact_phone: Optional[str] = None
+
+class ManagerRead(ManagerCreate):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class MarketplaceTokenCreate(BaseModel):
+    """Схема создания токена маркетплейса."""
+
+    store_id: int
+    service_name: str
+    token: str
+
+class MarketplaceTokenRead(MarketplaceTokenCreate):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class ProductCreate(BaseModel):
+    """Схема создания продукта."""
+
+    title: str
+    description: Optional[str] = None
+    specifications: Optional[Any] = None
+    marketplaces: Optional[List[str]] = Field(default_factory=list)
+
+class ProductRead(ProductCreate):
+    id: int
+    image_keys: List[str] = Field(default_factory=list)
+
+    class Config:
+        orm_mode = True
+
+class ConversationMessageCreate(BaseModel):
+    """Схема входящего сообщения."""
+
+    external_id: str
+    product: int
+    text: str
+    marketplace: str
+    from_manager: bool = False
+
+class ConversationMessageRead(ConversationMessageCreate):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/fastapi_app/app/storage.py
+++ b/fastapi_app/app/storage.py
@@ -1,0 +1,37 @@
+from typing import Iterable
+from uuid import uuid4
+from urllib.parse import urlparse
+
+from minio import Minio
+
+from .config import settings
+
+class MinioStorage:
+    """Класс для загрузки файлов в MinIO."""
+
+    def __init__(self) -> None:
+        parsed = urlparse(settings.minio_endpoint)
+        self.client = Minio(
+            endpoint=f"{parsed.hostname}:{parsed.port}" if parsed.port else parsed.hostname,
+            access_key=settings.minio_access_key,
+            secret_key=settings.minio_secret_key,
+            secure=parsed.scheme == "https",
+        )
+        self.bucket = settings.minio_bucket
+        if not self.client.bucket_exists(self.bucket):
+            self.client.make_bucket(self.bucket)
+
+    def upload_files(self, files: Iterable[bytes]) -> list[str]:
+        """Сохраняет файлы и возвращает их ключи."""
+        keys = []
+        for file_data in files:
+            key = f"{uuid4().hex}"
+            self.client.put_object(
+                bucket_name=self.bucket,
+                object_name=key,
+                data=file_data,
+                length=len(file_data),
+                content_type="application/octet-stream",
+            )
+            keys.append(key)
+        return keys

--- a/fastapi_app/requirements.txt
+++ b/fastapi_app/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pydantic
+sqlalchemy[asyncio]
+asyncpg
+minio


### PR DESCRIPTION
## Summary
- set up a new FastAPI application
- provide database models and CRUD
- add routers for managers, tokens, products and conversations
- support file storage via MinIO
- include requirements file

## Testing
- `pip install -r fastapi_app/requirements.txt`
- `python -m compileall fastapi_app`

------
https://chatgpt.com/codex/tasks/task_e_68614bf448dc8326b40c7a58e0c8cbb6